### PR TITLE
Display custom metedata description instead of node name in tooltip.

### DIFF
--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2243,8 +2243,14 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
 
 			// Draw tooltip
 			std::string tooltip_text = "";
-			if (hovering && !m_selected_item)
-				tooltip_text = item.getDefinition(m_gamedef->idef()).description;
+			if (hovering && !m_selected_item) {
+				ItemStackMetadata *meta = &item.metadata;
+				std::string desc = meta->getString("description");
+				if (desc != "")
+					tooltip_text = desc;
+				else
+					tooltip_text = item.getDefinition(m_gamedef->idef()).description;
+			}
 			if (tooltip_text != "") {
 				std::vector<std::string> tt_rows = str_split(tooltip_text, '\n');
 				m_tooltip_element->setBackgroundColor(m_default_tooltip_bgcolor);


### PR DESCRIPTION
This uses the new ItemStackMetadata subclass, and checks if the item
has a 'description' metadata string set. If set, the content of the
string is displayed, otherwise the description string from the
nodedef is used.